### PR TITLE
build() options.additionalProperties precedence

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -711,10 +711,12 @@ function build(schema, def, additional, resolver, parentMarker) {
             }
         }
 
+        var defaultAdditional = typeof additional === 'boolean' ? additional : schema.additionalProperties;
         for (key in def) {
             if (!(key in schema.properties) &&
-                (schema.additionalProperties === false ||
-                (additional === false && !schema.additionalProperties))) {
+                (defaultAdditional === false ||
+                (defaultAdditional !== true && schema.additionalProperties === false))
+            ) {
 
                 if (parentMarker) {
                     parentMarker.mark(def, key);

--- a/test/build.js
+++ b/test/build.js
@@ -705,7 +705,35 @@ describe('build', function () {
             assert.deepEqual(actual, expected);
         });
 
-        it('schema.additionalProperties takes precedence', function () {
+        it('build options.additionalProperties false takes precedence', function () {
+            var schema = {
+                    additionalProperties: true,
+                    properties: {
+                        foo: {}
+                    }
+                },
+                initial = { foo: 1, bar: 2 },
+                expected = { foo: 1 },
+                validate = jsen(schema);
+
+            assert.deepEqual(validate.build(initial, { additionalProperties: false }), expected);
+        });
+
+        it('build options.additionalProperties true takes precedence', function () {
+            var schema = {
+                    additionalProperties: false,
+                    properties: {
+                        foo: {}
+                    }
+                },
+                initial = { foo: 1, bar: 2 },
+                expected = { foo: 1, bar: 2 },
+                validate = jsen(schema);
+
+            assert.deepEqual(validate.build(initial, { additionalProperties: true }), expected);
+        });
+
+        it('build options.additionalProperties undefined falls back to schema.additionalProperties true', function () {
             var schema = {
                     additionalProperties: true,
                     properties: {
@@ -716,7 +744,21 @@ describe('build', function () {
                 expected = { foo: 1, bar: 2 },
                 validate = jsen(schema);
 
-            assert.deepEqual(validate.build(initial, { additionalProperties: false }), expected);
+            assert.deepEqual(validate.build(initial, { additionalProperties: void 0 }), expected);
+        });
+
+        it('build options.additionalProperties undefined falls back to schema.additionalProperties false', function () {
+            var schema = {
+                    additionalProperties: false,
+                    properties: {
+                        foo: {}
+                    }
+                },
+                initial = { foo: 1, bar: 2 },
+                expected = { foo: 1 },
+                validate = jsen(schema);
+
+            assert.deepEqual(validate.build(initial, { additionalProperties: void 0 }), expected);
         });
     });
 });


### PR DESCRIPTION
Issue #60. Allow build options 'additionalProperties' to take precedence over the schema.additionalProperties configuration. This allows the .build() function to apply default values and retain additional properties, which can then be validated. Without this change, it is not possible to apply defaults and retain additional properties, this is a problem if you want to return validation errors for any additional properties after applying default values.
